### PR TITLE
look everywhere for buildevents binary

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -54,9 +54,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux
+              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin
+              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
             fi
             # use that binary to report this step
             buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/be/build_start) << parameters.result >>
@@ -82,9 +82,9 @@ commands:
             # this way steps that are run within a span can use the raw buildevents if desired
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux" >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux" >> $BASH_ENV
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin" >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin" >> $BASH_ENV
             fi
 
       ### run the job's steps
@@ -93,11 +93,12 @@ commands:
       - run:
           name: finishing span for job
           command: |
+            set -x
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux
+              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin
+              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
             fi
             buildevents step $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/be/${CIRCLE_JOB}/span_id) \
@@ -121,9 +122,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux
+              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin
+              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
             fi
             buildevents cmd $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/be/${CIRCLE_JOB}/span_id) \

--- a/orb.yml
+++ b/orb.yml
@@ -93,7 +93,6 @@ commands:
       - run:
           name: finishing span for job
           command: |
-            set -x
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
               export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux


### PR DESCRIPTION
As described in #1 the buildevents binary may not be in the workspace. This change adds both to the PATH so that when `with_job_span` is in the same job as `start_trace` it can find bulidevents in the original download location.