### PR TITLE
Bump buildevents version to get access to circle API token

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -18,7 +18,7 @@ commands:
             date +%s > /tmp/be/build_start
 
             # get all buildevenst binaries so jobs in any OS will work
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://44-186895545-gh.circle-artifacts.com/0/go/src/github.com/honeycombio/buildevents/artifacts/buildevents
+            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.2.2/buildevents
             curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-darwin
 
             # make them executable

--- a/orb.yml
+++ b/orb.yml
@@ -18,7 +18,7 @@ commands:
             date +%s > /tmp/be/build_start
 
             # get all buildevenst binaries so jobs in any OS will work
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.2.1/buildevents
+            curl -q -L -o /tmp/be/bin-linux/buildevents https://44-186895545-gh.circle-artifacts.com/0/go/src/github.com/honeycombio/buildevents/artifacts/buildevents
             curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-darwin
 
             # make them executable


### PR DESCRIPTION
Version 0.2.2 of `buildevents` looks in the environment for a CircleCI API token to use when querying the API for the `watch_build_and_finish` command.