### PR TITLE
flesh out readme. add back finish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,42 @@
 # buildevents-orb
 Orb for CircleCI to instrument builds with Honeycomb
 
-TBD
+## Overview
 
-In the mean time, the [README for the main buildevents repo](https://github.com/honeycombio/buildevents) has lots of context on how it should be used.
+The Buildevents Orb is a convenient package for using Honeycomb's `buildevents` to instrument your CircleCI build. For the full documentation see the [`buildevents` repo](https://github.com/honeycombio/buildevents) itself.
 
-(See a working build as an example: https://github.com/honeycombio/samproxy/blob/master/.circleci/config.yml)
+The orb requires some environment variables to be set. At minimum:
+* `BUILDEVENT_APIKEY` - your Honeycomb API key, available on the [accounts](https://ui.honeycomb.io/account) page
+* `BUILDEVENT_CIRCLE_API_TOKEN` - a Personal CircleCI API Token, available from the [api tokens section](https://circleci.com/account/api) of your CircleCI account page
+
+Additional optional environment variables can be found in the [`buildevents`](https://github.com/honeycombio/buildevents) documentation.
+
+## Use
+
+The expected use of the Buildevents Orb adds two jobs to your workflow; the rest of the use is within existing jobs.
+
+```
+     [setup]  ----  [the rest of the build]
+        \
+          ----  [watch and finish]
+```
+
+**setup** Add a job that runs at the very beginning of the workflow that initializes the orb by downloading the `buildevents` binary and recording some starting information. This is the `start_trace` command.
+
+**watch** The watch job should depend on setup and have no jobs depending on it. It will poll the CircleCI API to determine when the build has finished and its status. It will continue to run until all other jobs have finished (or are blocked). This is the `watch_build_and_finish` command.
+
+**the rest of the build** Within each of your existing jobs there three other commands the orb supplies to be used.
+* `with_job_span` should be the only command in your job's `steps` section. It starts a span that will record the length of this job. It has its own `steps` command, in which all the things you want this job to do reside.
+* `add_context` is a way of recording additional fields you want to include in the job's span. Examples of useful additional context are parameters to the job and the size of artifacts.
+* `berun` is a way to create a span for a specific command within a job. Similar to the native `run` command, this takes a name and a command to run. The duration and exit status of the command will be recorded in a span.
+* `buildevents` the raw buildevents binary is available in the path as an alternative to the `berun` command. Doing so in a way that will create a span that will join the trace requires specific arguments: `buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID <name> -- <the command to run>`
+
+If it's impossible to get a Personal CircleCI API Token, you can use the `finish` command instead of `watch_build_and_finish`. You should schedule a job to be run as close to the end of the build as possible. If the job does not run (because a previous job failed) you will not get a root span for the build's trace (though all previous spans will still exist).
+
+## Examples
+
+Several of the Honeycomb repositories use buildevents and you can take a look as working examples:
+* [buildevents](https://github.com/honeycombio/buildevents/blob/master/.circleci/config.yml) builds itself using buildevents to instrument its own build.
+* [samproxy](https://github.com/honeycombio/samproxy/blob/master/.circleci/config.yml)
+* [honeytail](https://github.com/honeycombio/honeytail/blob/master/.circleci/config.yml)
 

--- a/orb.yml
+++ b/orb.yml
@@ -73,6 +73,30 @@ commands:
             export BUILDEVENT_TIMEOUT=<< parameters.timeout >>
             buildevents watch $CIRCLE_WORKFLOW_ID
 
+  finish:
+    description: |
+      finish is an alternative to watch_build_and_finish. If you can't create a
+      CircleCI API token or want to manually finish the trace, you can use this
+      command to do so. If you can, it's recommended that you use
+      watch_build_and_finish instead of this command.
+    parameters:
+      result:
+        description: The final status of the build. Should be either "success" or "failure".
+        type: string
+    steps:
+      - attach_workspace:
+          at: /tmp/buildevents
+      - run:
+          name: Finish the build by sending the root span
+          command: |
+            # choose the right buildevents binary
+            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
+              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
+            elif uname -a | grep Darwin > /dev/null 2>&1; then
+              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
+            fi
+            buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/be/build_start) << parameters.result >>
+
   with_job_span:
     parameters:
       steps:


### PR DESCRIPTION
Fills out initial usage instructions in the README. 

The previous commit that added polling against the CircleCI API removed the `finish` command that would let you manually finish a build. Since the `watch` command requires a CirlceCI API Token, it seems reasonable to assume there may be folks who can't use it and would prefer to have the `finish` command available. This diff adds it back in with some cautionary text recommending using the `watch` command if possible.