### PR TITLE
Fix add_context quoting

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -143,8 +143,8 @@ commands:
     steps:
       - run: |
           set -x
-          echo << parameters.field_name >>="<< parameters.field_value >>"
-      - run: echo << parameters.field_name >>="<< parameters.field_value >>" >> /tmp/buildevents/extra_fields.lgfmt
+          echo << parameters.field_name >>=\"<< parameters.field_value >>\"
+      - run: echo << parameters.field_name >>=\"<< parameters.field_value >>\" >> /tmp/buildevents/extra_fields.lgfmt
 
   berun:
     description: |

--- a/orb.yml
+++ b/orb.yml
@@ -141,7 +141,10 @@ commands:
         description: the value of the field to add to the surrounding step
         type: string
       verbose:
-        description: if set to `true`, the extra context field name and content will be echoed to your build log
+        description: |
+          if set to `true`, the extra context field name and content will be
+          evaluated and echoed to your build log in addition to being sent to
+          Hoenycomb
         type: boolean
         default: false
     steps:

--- a/orb.yml
+++ b/orb.yml
@@ -140,11 +140,18 @@ commands:
       field_value:
         description: the value of the field to add to the surrounding step
         type: string
+      verbose:
+        description: if set to `true`, the extra context field name and content will be echoed to your build log
+        type: string
+        default: "false"
     steps:
       - run: |
-          set -x
-          echo << parameters.field_name >>=\"<< parameters.field_value >>\"
-      - run: echo << parameters.field_name >>=\"<< parameters.field_value >>\" >> /tmp/buildevents/extra_fields.lgfmt
+          if [ "<< parameters.verbose >>" == "true" ] ; then
+            echo "adding the following context to the trace:"
+            echo field: << parameters.field_name >>
+            echo value: << parameters.field_value >>
+          fi
+          echo << parameters.field_name >>=\"<< parameters.field_value >>\" >> /tmp/buildevents/extra_fields.lgfmt
 
   berun:
     description: |

--- a/orb.yml
+++ b/orb.yml
@@ -141,7 +141,10 @@ commands:
         description: the value of the field to add to the surrounding step
         type: string
     steps:
-      - run: echo '<< parameters.field_name >>="<< parameters.field_value >>"' >> /tmp/buildevents/extra_fields.lgfmt
+      - run: |
+          set -x
+          echo << parameters.field_name >>="<< parameters.field_value >>"
+      - run: echo << parameters.field_name >>="<< parameters.field_value >>" >> /tmp/buildevents/extra_fields.lgfmt
 
   berun:
     description: |

--- a/orb.yml
+++ b/orb.yml
@@ -142,8 +142,8 @@ commands:
         type: string
       verbose:
         description: if set to `true`, the extra context field name and content will be echoed to your build log
-        type: string
-        default: "false"
+        type: boolean
+        default: false
     steps:
       - run: |
           if [ "<< parameters.verbose >>" == "true" ] ; then


### PR DESCRIPTION
The single quotes in the add context command defeated expanding shell variables or running subshells. I'm sure quoting will remain a problem, but this at least makes the marginally useful. 