### PR TITLE
bump buildevents release to v0.4.4

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -23,8 +23,8 @@ commands:
             date +%s > /tmp/be/build_start
 
             # get all buildevenst binaries so jobs in any OS will work
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.1/buildevents-linux-amd64
-            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.1/buildevents-darwin-amd64
+            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
+            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64
 
             # make them executable
             chmod 755 /tmp/be/bin-linux/buildevents


### PR DESCRIPTION
buildevents 0.4.4 works on alpine.  let's use that release.