### PR TITLE
Fix build_start file in finish command

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -7,24 +7,18 @@ description: |
   for use instructions
 
 commands:
-  restore_be_cache:
+  setup_buildevents:
     description: |
       internal buildevents orb command.  don't use this.
     steps:
       - restore_cache:
           key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
-
-  start_trace:
-    description: |
-      start_trace should be run in a job all on its own at the very beginning of
-      a build. This job initializes the buildevents config, downloads the
-      buildevents binary, and otherwise gets the build environment ready for the
-      rest of the jobs.
-    steps:
-      ### set up buildevents
       - run:
-          name: setup honeycomb buildevents and start trace
+          name: setup honeycomb buildevents
           command: |
+            # exit early if already setup
+            test -e /tmp/be/build_start && exit || true
+
             # set up our working environment and timestamp the trace
             mkdir -p /tmp/be/bin-linux /tmp/be/bin-darwin
             date +%s > /tmp/be/build_start
@@ -40,6 +34,15 @@ commands:
           key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
           paths:
             - /tmp/be
+
+  start_trace:
+    description: |
+      start_trace should be run in a job all on its own at the very beginning of
+      a build. This job initializes the buildevents config, downloads the
+      buildevents binary, and otherwise gets the build environment ready for the
+      rest of the jobs.
+    steps:
+      - setup_buildevents
       - run:
           name: report_step
           command: |
@@ -63,7 +66,7 @@ commands:
         type: integer
         default: 20
     steps:
-      - restore_be_cache
+      - setup_buildevents
       - run:
           name: watch then finish build trace
           command: |
@@ -88,7 +91,7 @@ commands:
         description: The final status of the build. Should be either "success" or "failure".
         type: string
     steps:
-      - restore_be_cache
+      - setup_buildevents
       - run:
           name: Finish the build by sending the root span
           command: |
@@ -105,7 +108,7 @@ commands:
       steps:
         type: steps
     steps:
-      - restore_be_cache
+      - setup_buildevents
       - run:
           name: starting span for job
           command: |

--- a/orb.yml
+++ b/orb.yml
@@ -82,9 +82,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
+              export PATH=$PATH:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
+              export PATH=$PATH:/tmp/be/bin-darwin
             fi
             # set the timeout
             export BUILDEVENT_TIMEOUT=<< parameters.timeout >>
@@ -107,9 +107,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
+              export PATH=$PATH:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
+              export PATH=$PATH:/tmp/be/bin-darwin
             fi
             buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/be/build_start) << parameters.result >>
 
@@ -132,9 +132,9 @@ commands:
             # this way steps that are run within a span can use the raw buildevents if desired
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux" >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/be/bin-linux" >> $BASH_ENV
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin" >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/be/bin-darwin" >> $BASH_ENV
             fi
 
       ### run the job's steps
@@ -145,9 +145,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
+              export PATH=$PATH:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
+              export PATH=$PATH:/tmp/be/bin-darwin
             fi
 
             # if there are any extra context values, add them
@@ -211,9 +211,9 @@ commands:
           command: |
             # choose the right buildevents binary
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
+              export PATH=$PATH:/tmp/be/bin-linux
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
+              export PATH=$PATH:/tmp/be/bin-darwin
             fi
             buildevents cmd $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/be/${CIRCLE_JOB}/span_id) \

--- a/orb.yml
+++ b/orb.yml
@@ -7,30 +7,12 @@ description: |
   for use instructions
 
 commands:
-  # the next three (internal) commands are all that require the buildevents release version.  make sure you replace the version in all of them
-  save_be_cache:
-    description: |
-      internal buildevents orb command.  don't use this.
-    steps:
-      - save_cache:
-          key: buildevents-v0.4.4
-          paths:
-            - /tmp/be
   restore_be_cache:
     description: |
       internal buildevents orb command.  don't use this.
     steps:
       - restore_cache:
-          key: buildevents-v0.4.4
-  download_be_executables:
-    description: |
-      internal buildevents orb command.  don't use this.
-    steps:
-      - run:
-          name: downloading buildevents executables
-          command: |
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
-            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64
+          key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
 
   start_trace:
     description: |
@@ -46,13 +28,18 @@ commands:
             # set up our working environment and timestamp the trace
             mkdir -p /tmp/be/bin-linux /tmp/be/bin-darwin
             date +%s > /tmp/be/build_start
-      - download_be_executables
-      - run:
-          name: make them executable
-          command: |
+
+            # get all buildevenst binaries so jobs in any OS will work
+            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
+            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64
+
+            # make them executable
             chmod 755 /tmp/be/bin-linux/buildevents
             chmod 755 /tmp/be/bin-darwin/buildevents
-      - save_be_cache
+      - save_cache:
+          key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
+          paths:
+            - /tmp/be
       - run:
           name: report_step
           command: |

--- a/orb.yml
+++ b/orb.yml
@@ -12,28 +12,39 @@ commands:
       internal buildevents orb command.  don't use this.
     steps:
       - restore_cache:
-          key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
+          keys:
+            - 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
+            - 'buildevents-v0.4.4'
       - run:
           name: setup honeycomb buildevents
           command: |
-            # exit early if already setup
-            test -e /tmp/be/build_start && exit || true
+            mkdir -p /tmp/be && cd /tmp/be
 
-            # set up our working environment and timestamp the trace
-            mkdir -p /tmp/be/bin-linux /tmp/be/bin-darwin
-            date +%s > /tmp/be/build_start
+            # exit early if already setup
+            test -e build_start && exit || true
+            date +%s > build_start
+
+            # exit early if already downloaded
+            test -e downloaded && exit || true
 
             # get all buildevenst binaries so jobs in any OS will work
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
-            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64
+            mkdir -p bin-linux bin-darwin
+            curl -q -L -o bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
+            curl -q -L -o bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64
 
             # make them executable
-            chmod 755 /tmp/be/bin-linux/buildevents
-            chmod 755 /tmp/be/bin-darwin/buildevents
+            chmod 755 bin-linux/buildevents
+            chmod 755 bin-darwin/buildevents
+
+            touch downloaded
       - save_cache:
           key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
           paths:
             - /tmp/be
+      - save_cache:
+          key: 'buildevents-v0.4.4'
+          paths:
+            - /tmp/be/bin-*
 
   start_trace:
     description: |

--- a/orb.yml
+++ b/orb.yml
@@ -27,7 +27,7 @@ commands:
             # exit early if already downloaded
             test -e downloaded && exit || true
 
-            # get all buildevenst binaries so jobs in any OS will work
+            # get all buildevents binaries so jobs in any OS will work
             mkdir -p bin-linux bin-darwin
             curl -q -L -o bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-linux-amd64
             curl -q -L -o bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.4/buildevents-darwin-amd64

--- a/orb.yml
+++ b/orb.yml
@@ -14,7 +14,7 @@ commands:
       - restore_cache:
           keys:
             - 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
-            - 'buildevents-v0.4.4'
+            - 'buildevents-2:v0.4.4'
       - run:
           name: setup honeycomb buildevents
           command: |
@@ -25,7 +25,7 @@ commands:
             date +%s > build_start
 
             # exit early if already downloaded
-            test -e downloaded && exit || true
+            test -e bin-linux/buildevents && test -e bin-darwin/buildevents && exit || true
 
             # get all buildevents binaries so jobs in any OS will work
             mkdir -p bin-linux bin-darwin
@@ -35,14 +35,12 @@ commands:
             # make them executable
             chmod 755 bin-linux/buildevents
             chmod 755 bin-darwin/buildevents
-
-            touch downloaded
       - save_cache:
           key: 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
           paths:
             - /tmp/be
       - save_cache:
-          key: 'buildevents-v0.4.4'
+          key: 'buildevents-2:v0.4.4'
           paths:
             - /tmp/be/bin-*
 

--- a/orb.yml
+++ b/orb.yml
@@ -111,7 +111,7 @@ commands:
             elif uname -a | grep Darwin > /dev/null 2>&1; then
               export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
             fi
-            buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/be/build_start) << parameters.result >>
+            buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/be/build_start) << parameters.result >>
 
   with_job_span:
     parameters:

--- a/orb.yml
+++ b/orb.yml
@@ -14,7 +14,7 @@ commands:
       - restore_cache:
           keys:
             - 'buildevents-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
-            - 'buildevents-2:v0.4.4'
+            - 'buildevents-3:v0.4.4'
       - run:
           name: setup honeycomb buildevents
           command: |
@@ -40,9 +40,10 @@ commands:
           paths:
             - /tmp/be
       - save_cache:
-          key: 'buildevents-2:v0.4.4'
+          key: 'buildevents-3:v0.4.4'
           paths:
-            - /tmp/be/bin-*
+            - /tmp/be/bin-linux
+            - /tmp/be/bin-darwin
 
   start_trace:
     description: |


### PR DESCRIPTION
Most people should be using the watch command anyway, but I was reading through the source and I noticed that the `build_start` file in the `finish` command seems to be wrong. Possibly an oversight in #13.

As an extra thing, I believe the PATH doesn't need to have two directories since the binaries are only in `/tmp/be/...`, right?

We are not using the `finish` command but if someone is, it is probably not sending the duration... 🤔

EDIT/TLDR: Ok. I kind of fell in the rabbit hole and continued going down. So this PR started by simply fixing the path of the `build_start` file for the `finish` command. But I was also trying to re-use the `build_start` file to calculate a "time to deploy" on our workflows, and then I noticed that the `build_start` file would actually belong to another workflow that ran a few hours ago. I fixed this on our side by creating a separate cache for the `build_start` file which is guaranteed to belong to the currently running workflow.

I tried to apply a similar solution here. I verified that is works by publishing a dev version of the orb and testing within carwow.