### PR TITLE
Add name to `add_context` command's run

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -187,13 +187,15 @@ commands:
         type: boolean
         default: false
     steps:
-      - run: |
-          if [ "<< parameters.verbose >>" == "true" ] ; then
-            echo "adding the following context to the trace:"
-            echo field: << parameters.field_name >>
-            echo value: << parameters.field_value >>
-          fi
-          echo << parameters.field_name >>=\"<< parameters.field_value >>\" >> /tmp/buildevents/extra_fields.lgfmt
+      - run:
+          name: adding << parameters.field_name >> to context
+          command: |
+            if [ "<< parameters.verbose >>" == "true" ] ; then
+              echo "adding the following context to the trace:"
+              echo field: << parameters.field_name >>
+              echo value: << parameters.field_value >>
+            fi
+            echo << parameters.field_name >>=\"<< parameters.field_value >>\" >> /tmp/buildevents/extra_fields.lgfmt
 
   berun:
     description: |

--- a/orb.yml
+++ b/orb.yml
@@ -188,7 +188,7 @@ commands:
         default: false
     steps:
       - run:
-          name: adding << parameters.field_name >> to context
+          name: adding extra field: << parameters.field_name >>
           command: |
             if [ "<< parameters.verbose >>" == "true" ] ; then
               echo "adding the following context to the trace:"


### PR DESCRIPTION
Otherwise the name is the full command which is a bit ugly 😅
<img width="1272" alt="Screenshot 2019-08-14 at 16 45 24" src="https://user-images.githubusercontent.com/938444/63035544-3d658e80-beb3-11e9-8bb7-6e096ef912d6.png">
