### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1,10 +1,11 @@
 version: 2.1
 
 description: |
-  Install and use the Honeycomb buildevents tool for generating traces of your builds
+  Generate traces of your builds for visual inspection on Honeycomb easily using our buildevents utility.
 
-  Please see the Buildevents Orb Readme (https://github.com/honeycombio/buildevents-orb)
-  for use instructions
+display:
+  source_url: https://github.com/honeycombio/buildevents-orb
+  home_url: https://www.honeycomb.io/
 
 commands:
   # the next three (internal) commands are all that require the buildevents release version.  make sure you replace the version in all of them


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Updated description, mostly rearranged the words to put the value proposition up front.