### PR TITLE
Set step result on both success and failure

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -33,6 +33,13 @@ commands:
             curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.11/buildevents-linux-amd64
             curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.4.11/buildevents-darwin-amd64
 
+  set_job_status:
+    description: |
+      internal buildevents orb command. don't use this.
+    steps:
+      - add_context:
+          result: "<< parameters.result >>"
+
   start_trace:
     description: |
       start_trace should be run in a job all on its own at the very beginning of
@@ -140,6 +147,14 @@ commands:
 
       ### run the job's steps
       - steps: << parameters.steps >>
+
+      - set_job_status:
+          result: "success"
+          when: "on_success"
+
+      - set_job_status:
+          result: "failure"
+          when: "on_fail"
 
       - run:
           name: finishing span for job


### PR DESCRIPTION
Right now there is no way to tell which step fails. This is particularly
helpful in the case of:
* Parallel steps where any one failure could fail the workflow
* Debugging flakey or low success rate jobs
* Jobs which have retries (automated or manual)

The `with_span` command works by running the call to Honeycomb in a
`when:always` wrapped step. To the best of my knowledge we do not know
the status of previous steps at this point, yet that is precisely what
we need to know to add that context.

In order to duplicate as little code as possible, I have introduced
independent `on_success` and `on_fail` steps which leverages the already
defined process of setting context via the `extra_fields.lgfmt` file.

resolves #22 