### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @honeycombio/telemetry-team


### PR DESCRIPTION
Adds `.github/CODEONWERS` to link @honeycombio/telemetry-team for PRs and issues.