### PR TITLE
update to buildevents to 0.6.0

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -14,7 +14,7 @@ commands:
       internal buildevents orb command.  don't use this.
     steps:
       - save_cache:
-          key: buildevents-v0.5.1
+          key: buildevents-v0.6.0
           paths:
             - /tmp/be
   restore_be_cache:
@@ -22,7 +22,7 @@ commands:
       internal buildevents orb command.  don't use this.
     steps:
       - restore_cache:
-          key: buildevents-v0.5.1
+          key: buildevents-v0.6.0
   download_be_executables:
     description: |
       internal buildevents orb command.  don't use this.
@@ -30,9 +30,9 @@ commands:
       - run:
           name: downloading buildevents executables
           command: |
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.5.1/buildevents-linux-amd64
-            curl -q -L -o /tmp/be/bin-linux-arm64/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.5.1/buildevents-linux-arm64
-            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.5.1/buildevents-darwin-amd64
+            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.6.0/buildevents-linux-amd64
+            curl -q -L -o /tmp/be/bin-linux-arm64/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.6.0/buildevents-linux-arm64
+            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.6.0/buildevents-darwin-amd64
 
   start_trace:
     description: |


### PR DESCRIPTION
Updates the orb to use use [v0.6.0](https://github.com/honeycombio/buildevents/releases/tag/v0.6.0) of buildevents.

Resolves #29 