### PR TITLE
Revert Set step result on both success and failure

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -34,13 +34,6 @@ commands:
             curl -q -L -o /tmp/be/bin-linux-arm64/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.6.0/buildevents-linux-arm64
             curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.6.0/buildevents-darwin-amd64
 
-  set_job_status:
-    description: |
-      internal buildevents orb command. don't use this.
-    steps:
-      - add_context:
-          result: "<< parameters.result >>"
-
   start_trace:
     description: |
       start_trace should be run in a job all on its own at the very beginning of
@@ -162,14 +155,6 @@ commands:
 
       ### run the job's steps
       - steps: << parameters.steps >>
-
-      - set_job_status:
-          result: "success"
-          when: "on_success"
-
-      - set_job_status:
-          result: "failure"
-          when: "on_fail"
 
       - run:
           name: finishing span for job


### PR DESCRIPTION
Unfortunately, we ned to revert #23 as it failed with config validation errors. This wasn't picked up int he PR, but builds against main are [failing](https://app.circleci.com/pipelines/github/honeycombio/buildevents-orb/105/workflows/b7388713-baaa-44e7-861b-114548464a9e/jobs/181).

Reopens #23.