### PR TITLE
report job status in CircleCI

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -157,6 +157,16 @@ commands:
       - steps: << parameters.steps >>
 
       - run:
+          name: record failure
+          command: echo status=\"failure\" >> /tmp/buildevents/extra_fields.lgfmt
+          when: on_fail
+
+      - run:
+          name: record success
+          command: echo status=\"success\" >> /tmp/buildevents/extra_fields.lgfmt
+          when: on_success
+
+      - run:
           name: finishing span for job
           command: |
             # choose the right buildevents binary


### PR DESCRIPTION
## Which problem is this PR solving?

CircleCI jobs do not report their status, only workflows. Having that would be useful for writing per-job triggers and analyzing job failure rates across a workflow.

## Short description of the changes

After running the steps in `with_job_span`, write a `status` context field, in the same way that `with_context` does.

Note that I have not tested this code and haven't figured out how to yet. Happy to take any pointers.