### PR TITLE
Use single quoted bash strings

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -139,13 +139,13 @@ commands:
             # in case this is a bash env, be kind and export the buildevents path and span ID
             # this orb won't rely on them but consumers of the orb might find it useful
             # this way steps that are run within a span can use the raw buildevents if desired
-            echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
+            echo 'export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID' >> $BASH_ENV
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux" >> $BASH_ENV
+              echo 'export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux' >> $BASH_ENV
             elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/be/bin-linux-arm64" >> $BASH_ENV
+              echo 'export PATH=$PATH:/tmp/be/bin-linux-arm64' >> $BASH_ENV
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin" >> $BASH_ENV
+              echo 'export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin' >> $BASH_ENV
             fi
             # Make sure the binaries are executable - this should have been done
             # in the setup job but we've seen it fail to keep the +x bit


### PR DESCRIPTION
I believe there's an issue with the way this orb works in that it will overwrite your config. Using double quotes means the line is evaluated when the echo command is executed, not when the file is sourced. This broke our $PATH in our project, and we were able to fix it by manually resetting the path later in the flow.

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Using this orb broke our $PATH environment variable. Upon debugging it looks like the culprit may have been double-quoted strings instead of single-quoted strings in these three lines.

## Short description of the changes

- I replaced double quoted strings with single quoted strings. I have not updated any kind of tests or anything.

