### PR TITLE
Don't run publish-dev step for dependabot and PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,6 @@ workflows:
             tags:
               only: /^v\d+\.\d+\.\d+/
             branches:
-              ignore: /.*/
+              ignore:
+              - /pull\/.*/
+              - /dependabot\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,6 @@ workflows:
               only: /^v\d+\.\d+\.\d+/
             branches:
               ignore:
-              - /pull\/.*/
-              - /dependabot\/.*/
+                - /.*/
+                - /pull\/.*/
+                - /dependabot\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ workflows:
           publish-branch-sha-version: true
           requires:
             - orb-tools/lint
+          filters:
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
   promote:
     jobs:
       - orb-tools/publish:
@@ -30,7 +35,4 @@ workflows:
             tags:
               only: /^v\d+\.\d+\.\d+/
             branches:
-              ignore:
-                - /.*/
-                - /pull\/.*/
-                - /dependabot\/.*/
+              ignore: /.*/


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Fixes a bug where the publish-dev step is executed for dependabot and PRs, which fails because it requires CircleCI secrets.

## Short description of the changes
- Don't run publish-dev step for dependabot and PRs