### PR TITLE
Use double-quotes for BUILDEVENTS_SPAN_ID

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -139,7 +139,7 @@ commands:
             # in case this is a bash env, be kind and export the buildevents path and span ID
             # this orb won't rely on them but consumers of the orb might find it useful
             # this way steps that are run within a span can use the raw buildevents if desired
-            echo 'export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID' >> $BASH_ENV
+            echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
               echo 'export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux' >> $BASH_ENV
             elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Fixes #72 

## Short description of the changes

- Ensures the `BUILDEVENTS_SPAN_ID` environment variable is set to the appropriate value by using double quotes rather than waiting for evaluation later and leaving it unset.
 
