### PR TITLE
Fix: Double quote vars that require interpolation

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -141,11 +141,11 @@ commands:
             # this way steps that are run within a span can use the raw buildevents if desired
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
             if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              echo 'export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux' >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux" >> $BASH_ENV
             elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              echo 'export PATH=$PATH:/tmp/be/bin-linux-arm64' >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/be/bin-linux-arm64" >> $BASH_ENV
             elif uname -a | grep Darwin > /dev/null 2>&1; then
-              echo 'export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin' >> $BASH_ENV
+              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin" >> $BASH_ENV
             fi
             # Make sure the binaries are executable - this should have been done
             # in the setup job but we've seen it fail to keep the +x bit


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The Orb can not use buildevent commands directly. Namely the command method throws an [error](https://github.com/honeycombio/buildevents/blob/main/cmd_cmd.go#L33) due to wrong number of parameters, which I have traced back to not having a Span ID.

Example error:
![image](https://user-images.githubusercontent.com/1557346/188985339-65d7389e-c8fc-479b-885a-1812ebd39c1d.png)

Given the following snippet:
```
    steps:
      - buildevents/with_job_span:
          steps:
            - checkout
            - setup_remote_docker:
                version: 20.10.14
                docker_layer_caching: true

            - run:
                name: Apt update
                command: |
                  buildevents cmd ${TRACE_ID} ${STEP_ID} 'apt update' -- sudo apt update
            
            - run:
                name: Install xpath for extracting test metrics
                command: |
                  buildevents cmd ${TRACE_ID} ${STEP_ID} 'install xpath' -- sudo apt install libxml-xpath-perl
```
-

## Short description of the changes

These three cases require interpolation of other environment variables. Use of single quotes was not allowing this interpolation, and in the case of  "BUILDEVENTS_SPAN_ID" the lack of this export causes issues with sending spans.

Workaround is possible if you manually set the span ID like:
```
- run:
     name: Sleep
     command: |
     export BUILDEVENTS_SPAN_ID=$(echo ${CIRCLE_JOB}-${CIRCLE_NODE_INDEX} | sha256sum | awk '{print $1}')
     buildevents cmd ${CIRCLE_WORKFLOW_ID} ${BUILDEVENTS_SPAN_ID} 'run dependencies' -- sleep 5
```

NOTE: My blocker is on the span ID, however I have updated the quotes for the path exports as well. Also, I am not sure how to test this as I am not sure how to get a test version of the orb without a commit to the repo. Happy to do the leg work if there is a path for this, else please do check before merging! Thanks 🙇


