### PR TITLE
Support benames with spaces

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -249,7 +249,7 @@ commands:
             fi
             buildevents cmd $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
-              << parameters.bename >> -- << parameters.becommand >>
+              "<< parameters.bename >>" -- << parameters.becommand >>
 
   create_marker:
     description: |


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

If a bename is sent with spaces in it, the buildevents command breaks by assuming more than one parameter.

Example error:
![image](https://user-images.githubusercontent.com/1557346/189480321-36eb017c-f876-4be0-acb1-08c412aeaee6.png)

## Short description of the changes

By quoting the string parameter we are able to send a name with spaces to the buildevents command as a single parameter.

Note: Per the example [here](https://circleci.com/docs/pipeline-variables#pipeline-values) I am assuming quoted parameter variables are supported!

![image](https://user-images.githubusercontent.com/1557346/189480355-6212f5ca-8123-4d9e-8fef-21c8dd83a108.png)


