### PR TITLE
support multi-line commands in berun

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -249,7 +249,7 @@ commands:
             fi
             buildevents cmd $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
-              "<< parameters.bename >>" -- << parameters.becommand >>
+              "<< parameters.bename >>" -- '<< parameters.becommand >>'
 
   create_marker:
     description: |


### PR DESCRIPTION
It appears that multi-line commands are not supported by this command, making tracing anything `run` commands difficult.

I haven't tested this yet, but I think that adding these quotes will allow the full command to be passed to buildevents, rather than just the first line.