### PR TITLE
docs: remove non-existent example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,3 @@ test:
           - command-using-pipeline-parameter:
               working_directory: << pipeline.parameters.working_directory >>
 ```
-
-## Examples
-
-Several of the Honeycomb repositories use buildevents and you can take a look as working examples:
-* [buildevents](https://github.com/honeycombio/buildevents/blob/main/.circleci/config.yml) builds itself using buildevents to instrument its own build.
-


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- buildevents [no longer uses buildevents](https://github.com/honeycombio/buildevents/pull/190)
- closes #86 

