### PR TITLE
refactor: Reduce final orb output size

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -16,7 +16,7 @@ commands:
       - save_cache:
           key: buildevents-v0.14.0{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
           paths:
-            - /tmp/be
+            - ~/project/bin
   restore_be_cache:
     description: |
       internal buildevents orb command.  don't use this.
@@ -30,9 +30,10 @@ commands:
       - run:
           name: downloading buildevents executables
           command: |
-            curl -q -L -o /tmp/be/bin-linux/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.14.0/buildevents-linux-amd64
-            curl -q -L -o /tmp/be/bin-linux-arm64/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.14.0/buildevents-linux-arm64
-            curl -q -L -o /tmp/be/bin-darwin/buildevents https://github.com/honeycombio/buildevents/releases/download/v0.14.0/buildevents-darwin-amd64
+            BASE_URL=https://github.com/honeycombio/buildevents/releases/download/v0.14.0
+            curl -q -L -o ~/project/bin/be-linux-x86_64/buildevents ${BASE_URL}/buildevents-linux-amd64
+            curl -q -L -o ~/project/bin/be-linux-aarch64/buildevents ${BASE_URL}/buildevents-linux-aarch64
+            curl -q -L -o ~/project/bin/be-darwin-arm64/buildevents ${BASE_URL}/buildevents-darwin-amd64
 
   start_trace:
     description: |
@@ -46,29 +47,16 @@ commands:
           name: setup honeycomb buildevents and start trace
           command: |
             # set up our working environment and timestamp the trace
-            mkdir -p /tmp/be/bin-linux /tmp/be/bin-linux-arm64 /tmp/be/bin-darwin
-            date +%s > /tmp/be/build_start
+            mkdir -p ~/project/bin/be-linux-x86_64 ~/project/bin/be-linux-aarch64 ~/project/bin/be-darwin-arm64/ /tmp/buildevents/
+            date +%s > /tmp/buildevents/build_start
       - download_be_executables
       - run:
           name: make them executable
-          command: |
-            chmod 755 /tmp/be/bin-linux/buildevents
-            chmod 755 /tmp/be/bin-linux-arm64/buildevents
-            chmod 755 /tmp/be/bin-darwin/buildevents
+          command: chmod 755 ~/project/bin/be*/buildevents
       - save_be_cache
       - run:
           name: report_step
-          command: |
-            # choose the right buildevents binary
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux-arm64
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/be/bin-darwin
-            fi
-            # use that binary to report this step
-            buildevents step $CIRCLE_WORKFLOW_ID setup $(cat /tmp/be/build_start) start_trace
+          command: ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID setup $(cat /tmp/buildevents/build_start) start_trace
 
   watch_build_and_finish:
     description: |
@@ -85,17 +73,9 @@ commands:
       - run:
           name: watch then finish build trace
           command: |
-            # choose the right buildevents binary
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux-arm64
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
-            fi
             # set the timeout
             export BUILDEVENT_TIMEOUT=<< parameters.timeout >>
-            buildevents watch $CIRCLE_WORKFLOW_ID
+            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents watch $CIRCLE_WORKFLOW_ID
 
   finish:
     description: |
@@ -112,15 +92,8 @@ commands:
       - run:
           name: Finish the build by sending the root span
           command: |
-            # choose the right buildevents binary
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux-arm64
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
-            fi
-            buildevents build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/be/build_start) << parameters.result >>
+            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents \
+            build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/build_start) << parameters.result >>
 
   with_job_span:
     parameters:
@@ -131,27 +104,17 @@ commands:
       - run:
           name: starting span for job
           command: |
-            mkdir -p /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}
-            date +%s > /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start
+            mkdir -p /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}
+            date +%s > /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start
             BUILDEVENTS_SPAN_ID=$(echo ${CIRCLE_JOB}-${CIRCLE_NODE_INDEX} | sha256sum | awk '{print $1}')
-            echo $BUILDEVENTS_SPAN_ID > /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id
+            echo $BUILDEVENTS_SPAN_ID > /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id
 
             # in case this is a bash env, be kind and export the buildevents path and span ID
             # this orb won't rely on them but consumers of the orb might find it useful
             # this way steps that are run within a span can use the raw buildevents if desired
+            
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux" >> $BASH_ENV
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              echo "export PATH=$PATH:/tmp/be/bin-linux-arm64" >> $BASH_ENV
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              echo "export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin" >> $BASH_ENV
-            fi
-            # Make sure the binaries are executable - this should have been done
-            # in the setup job but we've seen it fail to keep the +x bit
-            chmod 755 /tmp/be/bin-linux/buildevents
-            chmod 755 /tmp/be/bin-linux-arm64/buildevents
-            chmod 755 /tmp/be/bin-darwin/buildevents
+            echo "export PATH=$PATH:~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 
       ### run the job's steps
       - steps: << parameters.steps >>
@@ -169,24 +132,16 @@ commands:
       - run:
           name: finishing span for job
           command: |
-            # choose the right buildevents binary
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux-arm64
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
-            fi
-
             # if there are any extra context values, add them
             if [ -e /tmp/buildevents/extra_fields.lgfmt ] ; then
               export BUILDEVENT_FILE=/tmp/buildevents/extra_fields.lgfmt
             fi
 
             # go ahead and report the span
-            buildevents step $CIRCLE_WORKFLOW_ID \
-              $(cat /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
-              $(cat /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start) \
+            # choose the right buildevents binary
+            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID \
+              $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
+              $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start) \
               ${CIRCLE_JOB}
           when: always
 
@@ -239,16 +194,8 @@ commands:
       - run:
           name: << parameters.bename >>
           command: |
-            # choose the right buildevents binary
-            if uname -a | grep Linux | grep x86_64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-linux:/tmp/be/bin-linux
-            elif uname -a | grep Linux | grep -e arm64 -e aarch64 > /dev/null 2>&1 ; then
-              export PATH=$PATH:/tmp/be/bin-linux-arm64
-            elif uname -a | grep Darwin > /dev/null 2>&1; then
-              export PATH=$PATH:/tmp/buildevents/be/bin-darwin:/tmp/be/bin-darwin
-            fi
-            buildevents cmd $CIRCLE_WORKFLOW_ID \
-              $(cat /tmp/buildevents/be/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
+            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $CIRCLE_WORKFLOW_ID \
+              $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
               "<< parameters.bename >>" -- << parameters.becommand >>
 
   create_marker:

--- a/orb.yml
+++ b/orb.yml
@@ -112,7 +112,7 @@ commands:
             # in case this is a bash env, be kind and export the buildevents path and span ID
             # this orb won't rely on them but consumers of the orb might find it useful
             # this way steps that are run within a span can use the raw buildevents if desired
-            
+
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
             echo "export PATH=$PATH:~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 


### PR DESCRIPTION
## Which problem is this PR solving?

- I was trying to add this orb to the infra repo and the final config was too big. I noticed that the orb commands get repeated a lot in the final YAML, so I wanted to try to reduce their bulk.

## Short description of the changes

- Move executable files out of /tmp (sometimes tmpfs has noexec, which can cause problems) and into ~/project/bin
- determine architecture inline to avoid repeated lines
- it seems (unfortunately) that comments in inline bash scripts are included, so we might want to pull some of that out into the README or something.

## Results:
```
~/Projects/chonkyconfig via 🐍 pyenv py310 (py310) via 💎 v2.7.6 on ☁️  (us-east-1)
❯ ls -al
total 14088
drwxr-xr-x   6 tfield  staff      192 Jul 12 13:37 .
drwxr-xr-x  59 tfield  staff     1888 Jul 12 12:11 ..
-rw-r--r--   1 tfield  staff  2625806 Jul 11 17:27 config.yml
-rw-r--r--   1 tfield  staff      641 Jul 11 17:35 find_yaml_crimes.py
-rw-r--r--   1 tfield  staff  2004699 Jul 12 13:59 slimorbconfig.yml
```
So a ~23% reduction for our infra repo.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205067894802161