### PR TITLE
fix: Don't expand $PATH when writing to BASH_ENV

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -116,7 +116,7 @@ commands:
             # this way steps that are run within a span can use the raw buildevents if desired
 
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
-            echo "export PATH=$PATH:~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
+            echo 'export PATH=$PATH'":~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 
       ### run the job's steps
       - steps: << parameters.steps >>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When running `python3` in a sub-step of `buildevents/with_job_span`, I encountered this confusing error:

```
/opt/circleci/.pyenv/libexec/pyenv-exec: line 24: pyenv-version-name: command not found
```

After some digging, it appears that this is because the `buildevents/with_job_span` command provided by this orb writes a line like the following into the file located at `$BASH_ENV`:

```
export PATH=/bin:/usr/bin: ... :/home/circleci/project/bin/be-linux-aarch64
```

(`...` indicates path entries omitted for brevity) 

This seems sensible, but the problem is that that `export` no longer contains any reference to the `PATH` in effect at that time. The `PATH` is effectively frozen.

Instead, the command should write this into the file:

```
export PATH=$PATH:/home/circleci/project/bin/be-linux-aarch64
```

That way, the `be-linux-aarch64` directory will be appended to whatever the `PATH` is when this file is evaluated. [Here's an issue on a different repo that encountered the exact same bug](https://github.com/CircleCI-Public/gcp-cli-orb/issues/22).

## Short description of the changes

This PR changes the quoting of the `echo` used by `with_job_span` to fix the issue.

