### PR TITLE
fix: Use absolute path for binaries

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -16,7 +16,7 @@ commands:
       - save_cache:
           key: buildevents-v0.15.0-1{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
           paths:
-            - ~/project/bin
+            - /home/circleci/project/bin
   restore_be_cache:
     description: |
       internal buildevents orb command.  don't use this.
@@ -31,11 +31,11 @@ commands:
           name: downloading buildevents executables
           command: |
             BASE_URL=https://github.com/honeycombio/buildevents/releases/download/v0.15.0
-            curl -q -L -o ~/project/bin/be-linux-x86_64/buildevents ${BASE_URL}/buildevents-linux-amd64
+            curl -q -L -o /home/circleci/project/bin/be-linux-x86_64/buildevents ${BASE_URL}/buildevents-linux-amd64
             # Note: the URL says arm64, but the path on disk says aarch64
             # because that's a thing `uname` gives you.
-            curl -q -L -o ~/project/bin/be-linux-aarch64/buildevents ${BASE_URL}/buildevents-linux-arm64
-            curl -q -L -o ~/project/bin/be-darwin-arm64/buildevents ${BASE_URL}/buildevents-darwin-arm64
+            curl -q -L -o /home/circleci/project/bin/be-linux-aarch64/buildevents ${BASE_URL}/buildevents-linux-arm64
+            curl -q -L -o /home/circleci/project/bin/be-darwin-arm64/buildevents ${BASE_URL}/buildevents-darwin-arm64
 
   start_trace:
     description: |
@@ -49,16 +49,16 @@ commands:
           name: setup honeycomb buildevents and start trace
           command: |
             # set up our working environment and timestamp the trace
-            mkdir -p ~/project/bin/be-linux-x86_64 ~/project/bin/be-linux-aarch64 ~/project/bin/be-darwin-arm64/ /tmp/buildevents/
+            mkdir -p /home/circleci/project/bin/be-linux-x86_64 /home/circleci/project/bin/be-linux-aarch64 /home/circleci/project/bin/be-darwin-arm64/ /tmp/buildevents/
             date +%s > /tmp/buildevents/build_start
       - download_be_executables
       - run:
           name: make them executable
-          command: chmod 755 ~/project/bin/be*/buildevents
+          command: chmod 755 /home/circleci/project/bin/be*/buildevents
       - save_be_cache
       - run:
           name: report_step
-          command: ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID setup $(cat /tmp/buildevents/build_start) start_trace
+          command: /home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID setup $(cat /tmp/buildevents/build_start) start_trace
 
   watch_build_and_finish:
     description: |
@@ -77,7 +77,7 @@ commands:
           command: |
             # set the timeout
             export BUILDEVENT_TIMEOUT=<< parameters.timeout >>
-            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents watch $CIRCLE_WORKFLOW_ID
+            /home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents watch $CIRCLE_WORKFLOW_ID
 
   finish:
     description: |
@@ -94,7 +94,7 @@ commands:
       - run:
           name: Finish the build by sending the root span
           command: |
-            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents \
+            /home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents \
             build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/build_start) << parameters.result >>
 
   with_job_span:
@@ -116,7 +116,7 @@ commands:
             # this way steps that are run within a span can use the raw buildevents if desired
 
             echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
-            echo 'export PATH=$PATH'":~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
+            echo 'export PATH=$PATH'":/home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 
       ### run the job's steps
       - steps: << parameters.steps >>
@@ -141,7 +141,7 @@ commands:
 
             # go ahead and report the span
             # choose the right buildevents binary
-            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID \
+            /home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
               $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start) \
               ${CIRCLE_JOB}
@@ -196,7 +196,7 @@ commands:
       - run:
           name: << parameters.bename >>
           command: |
-            ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $CIRCLE_WORKFLOW_ID \
+            /home/circleci/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $CIRCLE_WORKFLOW_ID \
               $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
               "<< parameters.bename >>" -- << parameters.becommand >>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The home directory varies across CI docker images. In [CircleCI-provided convenience images](https://circleci.com/developer/images), the [user is `circleci`](https://github.com/CircleCI-Public/cimg-base/blob/dccdb1ca9a5fe61a4f9466e4ee9e8b5ffa7f13a3/22.04/Dockerfile#L141) and therefore the home directory is `/home/circleci`. However, on many docker images, the user might be `root` and use `/root` as a home directory. 

The problem is that the orb currently uses `~` in all its paths, even for commands that may run on different images. As a result, `download_be_executables` and `save_be_cache` write binaries to and cache them from `~/project/bin`. Later, commands that try to use these binaries, like `with_job_span`, also look in `~/project/bin`. But if the home directory differs between the image that cached the binaries and the one that restores the cache and tries to use them, the latter will fail to locate the binaries. For example, if the image that tries to use the binaries uses the `root` user, I observe the following error:

```
/bin/bash: line 8: /root/project/bin/be-linux-aarch64/buildevents: No such file or directory
```

## Short description of the changes

This PR makes all of the paths in the orb absolute, rooted in `/home/circleci`. The rationale for that directory is that for CircleCI-provided convenience images, the binaries will be in the same spot they always were. This is also a directory that should be writable for both common uses: CircleCI images will be able to write to their own home directory, while images using `root` will be able to write anywhere. 

