### PR TITLE
fix: job names containing spaces should still work

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -48,6 +48,10 @@ workflows:
       - integration:
           requires: ['setup']
           filters: *filters
+      - integration:
+          name: "integration, but job name has spaces"
+          requires: ['setup']
+          filters: *filters
 
       # The orb must be re-packed for publishing
       - orb-tools/pack:

--- a/src/commands/berun.yml
+++ b/src/commands/berun.yml
@@ -12,5 +12,5 @@ steps:
       name: << parameters.bename >>
       command: |
         ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $CIRCLE_WORKFLOW_ID \
-          $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
+          $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id") \
           "<< parameters.bename >>" -- << parameters.becommand >>

--- a/src/commands/with_job_span.yml
+++ b/src/commands/with_job_span.yml
@@ -11,10 +11,10 @@ steps:
   - run:
       name: starting span for job
       command: |
-        mkdir -p /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}
-        date +%s > /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start
-        BUILDEVENTS_SPAN_ID=$(echo ${CIRCLE_JOB}-${CIRCLE_NODE_INDEX} | sha256sum | awk '{print $1}')
-        echo $BUILDEVENTS_SPAN_ID > /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id
+        mkdir -p "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}"
+        date +%s > "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start"
+        BUILDEVENTS_SPAN_ID=$(echo "${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}" | sha256sum | awk '{print $1}')
+        echo $BUILDEVENTS_SPAN_ID > "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id"
 
         # in case this is a bash env, be kind and export the buildevents path and span ID
         # this orb won't rely on them but consumers of the orb might find it useful
@@ -47,7 +47,7 @@ steps:
         # go ahead and report the span
         # choose the right buildevents binary
         ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID \
-          $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id) \
-          $(cat /tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start) \
-          ${CIRCLE_JOB}
+          $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id") \
+          $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start") \
+          "${CIRCLE_JOB}"
       when: always


### PR DESCRIPTION
## Which problem is this PR solving?

- Job names containing spaces break (see https://github.com/honeycombio/buildevents-orb/pull/105/commits for a repro case).

## Short description of the changes

- Quote bash strings;  ${CIRCLE_JOB} may contain spaces, so since we create a dir there and redirect data there, we really should quote it to avoid breaking. (As happened in https://github.com/honeycombio/infra/pull/5992 .)

