### PR TITLE
maint: update repo for pipeline team ownership

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,8 @@ Please see our [OSS process document](https://github.com/honeycombio/home/blob/m
 
 ## Which problem is this PR solving?
 
--
+- Closes #<enter issue here>
 
 ## Short description of the changes
 
--
-
+## How to verify that this has the expected result

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,8 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
+        - "type: documentation"
     - title: 🤷 Other Changes
       labels:
         - "*"

--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -1,0 +1,15 @@
+name: Add to project
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    name: Add issues and PRs to project
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/honeycombio/projects/27
+          github-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,12 @@
 # Releasing
 
-- Update `CHANGELOG.md` with the changes since the last release.
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
-- Apply a tag for the new version on the merged commit: vX.Y.Z, for example v1.1.2.
-- Push the new version tag up to the project repository to kick off build and artifact publishing to the Orb registry.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
+- Push the new version tag up to the project repository to kick off build and artifact publishing to the Orb registry e.g. `git push origin v2.3.1`
 - Create a release in GitHub from the new tag.
+- Click "generate release notes" in GitHub for full changelog notes and any new contributors.
+- Publish the GitHub release.


### PR DESCRIPTION
## Which problem is this PR solving?

- finish handoff of repo to pipeline team

## Short description of the changes

- add github workflow for github project
- add detail to PR template, release.yml, releasing doc

