### PR TITLE
feat(w3c): partially implement w3c tracecontext

### DIFF
--- a/src/commands/berun.yml
+++ b/src/commands/berun.yml
@@ -11,6 +11,6 @@ steps:
   - run:
       name: << parameters.bename >>
       command: |
-        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $CIRCLE_WORKFLOW_ID \
+        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents cmd $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g') \
           $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id") \
           "<< parameters.bename >>" -- << parameters.becommand >>

--- a/src/commands/finish.yml
+++ b/src/commands/finish.yml
@@ -14,4 +14,4 @@ steps:
       name: Finish the build by sending the root span
       command: |
         ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents \
-        build $CIRCLE_WORKFLOW_ID $(cat /tmp/buildevents/build_start) << parameters.result >>
+        build $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g') $(cat /tmp/buildevents/build_start) << parameters.result >>

--- a/src/commands/start_trace.yml
+++ b/src/commands/start_trace.yml
@@ -28,4 +28,4 @@ steps:
         - ~/project/bin
   - run:
       name: report_step
-      command: ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID setup $(cat /tmp/buildevents/build_start) start_trace
+      command: ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g') setup $(cat /tmp/buildevents/build_start) start_trace

--- a/src/commands/watch_build_and_finish.yml
+++ b/src/commands/watch_build_and_finish.yml
@@ -15,4 +15,4 @@ steps:
       command: |
         # set the timeout
         export BUILDEVENT_TIMEOUT=<< parameters.timeout >>
-        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents watch $CIRCLE_WORKFLOW_ID
+        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents watch $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g')

--- a/src/commands/with_job_span.yml
+++ b/src/commands/with_job_span.yml
@@ -13,7 +13,7 @@ steps:
       command: |
         mkdir -p "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}"
         date +%s > "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start"
-        BUILDEVENTS_SPAN_ID=$(echo "${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}" | sha256sum | awk '{print $1}')
+        BUILDEVENTS_SPAN_ID=$(echo "${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}" | sha256sum | awk '{print substr($1, 1, 16)}')
         echo $BUILDEVENTS_SPAN_ID > "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id"
 
         # in case this is a bash env, be kind and export the buildevents path and span ID
@@ -46,7 +46,7 @@ steps:
 
         # go ahead and report the span
         # choose the right buildevents binary
-        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $CIRCLE_WORKFLOW_ID \
+        ~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)/buildevents step $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g') \
           $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id") \
           $(cat "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/start") \
           "${CIRCLE_JOB}"

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -35,4 +35,4 @@ usage:
               - run: yarn --immutable
               - run: >
                   # buildevents can be used directly for even more spans
-                  buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID yarn-test -- yarn test
+                  buildevents cmd $(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g') $BUILDEVENTS_SPAN_ID yarn-test -- yarn test


### PR DESCRIPTION
## Which problem is this PR solving?

Sub-steps within a run command cannot use TRACEPARENT env var because our current traceid and spanid are not w3c conformant.

## Short description of the changes

* Omits dashes from trace UUID
* Shortens span id's with the exception of the root watch span, to 16 hex chars to comply with w3c

## How to verify that this has the expected result

Test in dogfood buildevents. (also bees look in OSS CI env!)