### PR TITLE
maint(deps): upgrade buildevents binary

### DIFF
--- a/src/commands/finish.yml
+++ b/src/commands/finish.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
 steps:
   - restore_cache:
-      key: buildevents-v0.16.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
+      key: buildevents-v0.17.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
   - run:
       name: Finish the build by sending the root span
       command: |

--- a/src/commands/start_trace.yml
+++ b/src/commands/start_trace.yml
@@ -13,7 +13,7 @@ steps:
   - run:
       name: downloading buildevents executables
       command: |
-        BASE_URL=https://github.com/honeycombio/buildevents/releases/download/v0.16.0
+        BASE_URL=https://github.com/honeycombio/buildevents/releases/download/v0.17.0
         curl -q -L -o ~/project/bin/be-linux-x86_64/buildevents ${BASE_URL}/buildevents-linux-amd64
         # Note: the URL says arm64, but the path on disk says aarch64
         # because that's a thing `uname` gives you.
@@ -23,7 +23,7 @@ steps:
       name: make them executable
       command: chmod 755 ~/project/bin/be*/buildevents
   - save_cache:
-      key: buildevents-v0.16.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
+      key: buildevents-v0.17.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
       paths:
         - ~/project/bin
   - run:

--- a/src/commands/watch_build_and_finish.yml
+++ b/src/commands/watch_build_and_finish.yml
@@ -9,7 +9,7 @@ parameters:
     default: 20
 steps:
   - restore_cache:
-      key: buildevents-v0.16.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
+      key: buildevents-v0.17.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
   - run:
       name: watch then finish build trace
       command: |

--- a/src/commands/with_job_span.yml
+++ b/src/commands/with_job_span.yml
@@ -7,7 +7,7 @@ parameters:
     type: steps
 steps:
   - restore_cache:
-      key: buildevents-v0.16.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
+      key: buildevents-v0.17.0-2{{ .Environment.BUILDEVENTS_CACHE_VERSION }}
   - run:
       name: starting span for job
       command: |


### PR DESCRIPTION
## Which problem is this PR solving?

Upgrades buildevents binary to https://github.com/honeycombio/buildevents/releases/tag/v0.17.0