### PR TITLE
maint: add publish-dev step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ filters: &filters
   tags:
     only: /.*/
 
+dev_filters: &dev_filters
+  branches:
+    only: main
 
 workflows:
   build:
@@ -28,3 +31,14 @@ workflows:
           orb_name: buildevents
           requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
           filters: *filters
+  publish_dev:
+    jobs:
+      - orb-tools/pack:
+          filters: *dev_filters
+      - orb-tools/publish:
+          filters: *dev_filters
+          name: dev_publish
+          vcs_type: << pipeline.project.type >>
+          orb_name: buildevents
+          pub_type: dev
+          requires: [orb-tools/pack]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ filters: &filters
 
 dev_filters: &dev_filters
   branches:
-    only: main
+    only: jamie.publish-dev
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,24 @@ dev_filters: &dev_filters
     only: jamie.publish-dev
 
 workflows:
-  build:
-    jobs:
-      - orb-tools/lint:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
-          orb_name: buildevents
-          filters: *filters
-          exclude: RC009,RC010
-      - shellcheck/check:
-          filters: *filters
-      - orb-tools/continue:
-          pipeline_number: << pipeline.number >>
-          vcs_type: << pipeline.project.type >>
-          orb_name: buildevents
-          requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
-          filters: *filters
+  # build:
+  #   jobs:
+  #     - orb-tools/lint:
+  #         filters: *filters
+  #     - orb-tools/pack:
+  #         filters: *filters
+  #     - orb-tools/review:
+  #         orb_name: buildevents
+  #         filters: *filters
+  #         exclude: RC009,RC010
+  #     - shellcheck/check:
+  #         filters: *filters
+  #     - orb-tools/continue:
+  #         pipeline_number: << pipeline.number >>
+  #         vcs_type: << pipeline.project.type >>
+  #         orb_name: buildevents
+  #         requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
+  #         filters: *filters
   publish_dev:
     jobs:
       - orb-tools/pack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
           filters: *dev_filters
           name: dev_publish
           vcs_type: << pipeline.project.type >>
-          orb_name: buildevents
+          orb_name: honeycombio/buildevents
           pub_type: dev
           requires: [orb-tools/pack]
+          context: orb-publishing


### PR DESCRIPTION
**DO NOT MERGE. Currently this is just publishing a dev orb from my branch to try things out.** 

## Which problem is this PR solving?

- Maybe this lets us publish dev orbs on merges to main?

## Short description of the changes

- add workflow to publish merges to main as dev orbs

according to [orb-tools/publish docs](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish) on `pub_type`:
>Select the publishing type. Available options are "dev" and "production". If "production" is selected, the orb will be published to the orb registry only if the $CIRCLE_TAG environment variable is set. Publishing will be skipped otherwise. If "dev" is selected, two tags will be created: "dev:alpha" and "dev:<SHA1>".

## How to verify that this has the expected result

A merge to main should publish dev:alpha. Reviewing this I'm seeing other publishing happens in test-deploy so maybe this should live there? And/or we should move those steps back to the main file. 

**DO NOT MERGE. Currently this is just publishing a dev orb from my branch to try things out.** 