### PR TITLE
feat(w3c): add BE trace_id and TRACEPARENT to env

### DIFF
--- a/src/commands/with_job_span.yml
+++ b/src/commands/with_job_span.yml
@@ -16,11 +16,14 @@ steps:
         BUILDEVENTS_SPAN_ID=$(echo "${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}" | sha256sum | awk '{print substr($1, 1, 16)}')
         echo $BUILDEVENTS_SPAN_ID > "/tmp/buildevents/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}/span_id"
 
-        # in case this is a bash env, be kind and export the buildevents path and span ID
+        # in case this is a bash env, be kind and export the buildevents path, trace ID, and span ID
         # this orb won't rely on them but consumers of the orb might find it useful
         # this way steps that are run within a span can use the raw buildevents if desired
 
         echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
+        BUILDEVENTS_TRACE_ID=$(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g')
+        echo "export BUILDEVENTS_TRACE_ID=$BUILDEVENTS_TRACE_ID" >> $BASH_ENV
+        echo "export TRACEPARENT=00-${BUILDEVENTS_TRACE_ID}-${BUILDEVENTS_SPAN_ID}-01" >> $BASH_ENV
         echo 'export PATH=$PATH'":~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 
   ### run the job's steps

--- a/src/commands/with_job_span.yml
+++ b/src/commands/with_job_span.yml
@@ -23,7 +23,7 @@ steps:
         echo "export BUILDEVENTS_SPAN_ID=$BUILDEVENTS_SPAN_ID" >> $BASH_ENV
         BUILDEVENTS_TRACE_ID=$(echo $CIRCLE_WORKFLOW_ID | sed 's/-//g')
         echo "export BUILDEVENTS_TRACE_ID=$BUILDEVENTS_TRACE_ID" >> $BASH_ENV
-        echo "export TRACEPARENT=00-${BUILDEVENTS_TRACE_ID}-${BUILDEVENTS_SPAN_ID}-01" >> $BASH_ENV
+        echo "export TRACEPARENT=\"00-${BUILDEVENTS_TRACE_ID}-${BUILDEVENTS_SPAN_ID}-01\"" >> $BASH_ENV
         echo 'export PATH=$PATH'":~/project/bin/be-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" >> $BASH_ENV
 
   ### run the job's steps


### PR DESCRIPTION
## Which problem is this PR solving?

We have to manually set this up in `tools/ci/setup_env_vars.sh` in hound but really the library should handle for us.

## Short description of the changes

In with_job_span, we should be nice and export the vars that you'd expect to see. we can't guarantee W3C compliance for the other templates, but this template we can.

## How to verify that this has the expected result

Dogfood hound BE data